### PR TITLE
feat(ci): support optional wireguard tunnel on sign-in/sign-out runners

### DIFF
--- a/.github/actions/setup-wireguard/action.yml
+++ b/.github/actions/setup-wireguard/action.yml
@@ -1,0 +1,41 @@
+name: Setup WireGuard
+description: >
+  Optionally establish a WireGuard tunnel on the runner so the sign-in/sign-out
+  request appears to come from a configured network (e.g. campus) and may skip
+  CAPTCHA. Does nothing when the config input is empty, so existing workflows
+  are unaffected.
+
+inputs:
+  config:
+    description: >
+      Content of a wg0.conf file. Leave empty to skip the tunnel setup.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install WireGuard tools
+      if: ${{ inputs.config != '' }}
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y wireguard-tools
+
+    - name: Start WireGuard tunnel
+      if: ${{ inputs.config != '' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo tee /etc/wireguard/wg0.conf >/dev/null <<'__WG_CONF_EOF__'
+        ${{ inputs.config }}
+        __WG_CONF_EOF__
+        sudo chmod 600 /etc/wireguard/wg0.conf
+        if sudo modprobe wireguard 2>/dev/null; then
+          sudo wg-quick up wg0
+        else
+          echo "Kernel WireGuard module unavailable; falling back to wireguard-go (user-space)."
+          sudo apt-get install -y wireguard-go
+          sudo env WG_QUICK_USERSPACE_IMPLEMENTATION=wireguard-go wg-quick up wg0
+        fi
+        sudo wg show

--- a/.github/workflows/runner-sign-docker.yml
+++ b/.github/workflows/runner-sign-docker.yml
@@ -16,6 +16,11 @@ jobs:
     - name: Docker Pull
       run: docker pull wulukewu/mcl-sign-in-system:latest
 
+    - name: Setup WireGuard (optional)
+      uses: ./.github/actions/setup-wireguard
+      with:
+        config: ${{ secrets.wg_conf }}
+
     - name: Docker Sign In or Sign Out
       run: |
         username="${{ secrets.username }}"

--- a/.github/workflows/runner-sign.yml
+++ b/.github/workflows/runner-sign.yml
@@ -21,6 +21,11 @@ jobs:
           pip install --upgrade setuptools
           pip install -r requirements.txt
 
+      - name: Setup WireGuard (optional)
+        uses: ./.github/actions/setup-wireguard
+        with:
+          config: ${{ secrets.wg_conf }}
+
       - name: Run Sign In or Sign Out
         env:
           username: ${{ secrets.username }}

--- a/.github/workflows/runner-signin-docker.yml
+++ b/.github/workflows/runner-signin-docker.yml
@@ -19,6 +19,11 @@ jobs:
     - name: Docker Pull
       run: docker pull wulukewu/mcl-sign-in-system:latest
 
+    - name: Setup WireGuard (optional)
+      uses: ./.github/actions/setup-wireguard
+      with:
+        config: ${{ secrets.wg_conf }}
+
     - name: Docker Sign In
       run: |
         username="${{ secrets.username }}"

--- a/.github/workflows/runner-signin.yml
+++ b/.github/workflows/runner-signin.yml
@@ -24,6 +24,11 @@ jobs:
           pip install --upgrade setuptools
           pip install -r requirements.txt
 
+      - name: Setup WireGuard (optional)
+        uses: ./.github/actions/setup-wireguard
+        with:
+          config: ${{ secrets.wg_conf }}
+
       - name: Run Sign In
         env:
           inorout: signin

--- a/.github/workflows/runner-signout-docker.yml
+++ b/.github/workflows/runner-signout-docker.yml
@@ -19,6 +19,11 @@ jobs:
     - name: Docker Pull
       run: docker pull wulukewu/mcl-sign-in-system:latest
 
+    - name: Setup WireGuard (optional)
+      uses: ./.github/actions/setup-wireguard
+      with:
+        config: ${{ secrets.wg_conf }}
+
     - name: Docker Sign Out
       run: |      
         username="${{ secrets.username }}"

--- a/.github/workflows/runner-signout.yml
+++ b/.github/workflows/runner-signout.yml
@@ -24,6 +24,11 @@ jobs:
           pip install --upgrade setuptools
           pip install -r requirements.txt
 
+      - name: Setup WireGuard (optional)
+        uses: ./.github/actions/setup-wireguard
+        with:
+          config: ${{ secrets.wg_conf }}
+
       - name: Run Sign Out
         env:
           inorout: signout

--- a/README.md
+++ b/README.md
@@ -44,7 +44,31 @@ If you're using GitHub Actions, add the following secrets under your repository 
 - `discord_token` [optional]: Discord bot token to send notifications.
 - `discord_guild_id` [optional]: Discord guild (server) ID where the notification should be sent.
 - `discord_channel_id` [optional]: Discord channel ID where the notification should be sent.
+- `wg_conf` [optional]: Content of a WireGuard config file (`wg0.conf`). If provided, the workflow will establish a WireGuard tunnel before running the script, so the request comes from the configured network (e.g. on-campus) and may bypass the CAPTCHA that is usually shown outside the campus network. If not provided, the tunnel step is skipped entirely.
   Remember to adjust the `inorout` value as needed.
+
+## WireGuard Tunnel (Optional)
+
+When the sign-in/sign-out job runs on GitHub Actions, its network comes from GitHub's datacenter (off-campus). The portal may therefore show a reCAPTCHA. If you have a WireGuard server reachable from the campus network (or from whichever network lets the portal log in without CAPTCHA), you can route the runner through it.
+
+1. Prepare a `wg0.conf` file, e.g.:
+
+```ini
+[Interface]
+PrivateKey = ...
+Address = 10.0.0.2/24
+
+[Peer]
+PublicKey = ...
+AllowedIPs = 0.0.0.0/0
+Endpoint = campus-vpn.example.com:51820
+```
+
+2. Add the **whole file content** as a repository secret named `wg_conf` (Settings → Secrets and variables → Actions → New repository secret, then paste the multi-line content into the value field).
+
+3. Nothing else needs to change. The `Setup WireGuard (optional)` step in every workflow activates only when `wg_conf` exists; otherwise it is skipped and the pipeline behaves exactly as before.
+
+Note: `AllowedIPs` decides which traffic goes through the tunnel. Use the portal's network range instead of `0.0.0.0/0` if your WireGuard server does not route all traffic.
 
 ## Parameters
 


### PR DESCRIPTION
## Summary

When the sign-in/sign-out workflows run on GitHub Actions, their traffic originates from GitHub's datacenter (off-campus), which can trigger a reCAPTCHA on the portal. This PR lets the runner establish an optional WireGuard tunnel before the script runs, so the request appears to come from a configured network (e.g. on-campus) and may skip the CAPTCHA.

## Changes

- Add a composite action `.github/actions/setup-wireguard` that installs wireguard-tools, writes the provided config to `/etc/wireguard/wg0.conf`, and brings the tunnel up via `wg-quick up wg0` (falls back to user-space `wireguard-go` when the kernel module is unavailable).
- Insert a `Setup WireGuard (optional)` step into all 6 runners (sign/signin/signout \u00d7 Python/Docker).
- The step is skipped entirely when the `wg_conf` secret is not set, so existing setups are unaffected.
- Document the new `wg_conf` secret and a `WireGuard Tunnel (Optional)` section in the README.

## Usage

Set a new repository secret `wg_conf` containing the full `wg0.conf` content. See README for details.